### PR TITLE
Fix NullPointerException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target
 server
 build.sh
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
   <groupId>com.rooxchicken.dupepatch</groupId>
   <artifactId>dupepatch</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
 
   <name>dupepatch</name>
   <!-- FIXME change it to the project's website -->
-  <url>http://www.example.com</url>
+  <url>https://github.com/RooXChicken/papermc-dupe-patch/</url>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/rooxchicken/dupepatch/DupePatch.java
+++ b/src/main/java/com/rooxchicken/dupepatch/DupePatch.java
@@ -18,9 +18,11 @@ public class DupePatch extends JavaPlugin implements Listener
     }
 
     @EventHandler
+    @SuppressWarnings("unused")
     public void preventDupe(PlayerEditBookEvent event)
     {
-        if(event.getNewBookMeta().getTitle().length() > 15)
+        final String title = event.getNewBookMeta().getTitle();
+        if(title != null && title.length() > 15)
         {
             event.setCancelled(true);
             Bukkit.getLogger().log(Level.WARNING, "Player " + event.getPlayer().getName() + " is attempting to dupe!");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 main: com.rooxchicken.dupepatch.DupePatch
 name: BookAndQuillDupePatch
-version: 1.0
+version: 1.1
 api-version: '1.21'


### PR DESCRIPTION
On my server I saw this error:
```
[15:44:26] [Server thread/ERROR]: Could not pass event PlayerEditBookEvent to BookAndQuillDupePatch v1.0
java.lang.NullPointerException: Cannot invoke "String.length()" because the return value of "org.bukkit.inventory.meta.BookMeta.getTitle()" is null
        at PaperMCDupePatch.jar/com.rooxchicken.dupepatch.DupePatch.preventDupe(DupePatch.java:23) ~[PaperMCDupePatch.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor109.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-api-1.21-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21-R0.1-SNAPSHOT.jar:1.21-106-3a47518]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.21-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.jar:1.21-106-3a47518]
```

This fixes the case where title == null to not dump this error.

I also bumped the version to 1.1